### PR TITLE
Update cui-parent to 1.1.0 and Java baseline to 21

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,5 +2,5 @@ name: cui-test-keycloak-integration
 pages-reference: cui-test-keycloak-integration
 sonar-project-key: cuioss_cui-test-keycloak-integration
 release:
-  current-version: 1.0.1
-  next-version: 1.1.0-SNAPSHOT
+  current-version: 1.1.0
+  next-version: 1.2.0-SNAPSHOT

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,10 +31,10 @@ jobs:
           metadata-file-path: '.github/project.yml'
           local-file: true
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 17,21,24 ]
+        version: [ 21,24 ]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -28,7 +28,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven, Java ${{ matrix.version }}
-        run: ./mvnw --no-transfer-progress verify -Dmaven.compiler.source=${{ matrix.version }} -Dmaven.compiler.target=${{ matrix.version }}
+        run: ./mvnw --no-transfer-progress verify -Dmaven.compiler.release=${{ matrix.version }}
 
   sonar-build:
     needs: build
@@ -44,10 +44,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17 for Sonar-build
+      - name: Set up JDK 21 for Sonar-build
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -83,10 +83,10 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up JDK 17 for snapshot release
+      - name: Set up JDK 21 for snapshot release
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 
 image:https://github.com/cuioss/cui-test-keycloak-integration/actions/workflows/maven.yml/badge.svg[Java CI with Maven,link=https://github.com/cuioss/cui-test-keycloak-integration/actions/workflows/maven.yml]
 image:http://img.shields.io/:license-apache-blue.svg[License,link=http://www.apache.org/licenses/LICENSE-2.0.html]
-image:https://maven-badges.herokuapp.com/maven-central/de.cuioss.test/cui-test-keycloak-integration/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/de.cuioss.test/cui-test-keycloak-integration]
+image:https://img.shields.io/maven-central/v/de.cuioss.test/cui-test-keycloak-integration.svg?label=Maven%20Central["Maven Central", link="https://central.sonatype.com/artifact/de.cuioss.test/cui-test-keycloak-integration"]
 
 https://sonarcloud.io/summary/new_code?id=cuioss_cui-test-keycloak-integration[image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_cui-test-keycloak-integration&metric=alert_status[Quality
 Gate Status]]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>0.9.9.6</version>
+        <version>1.1.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.test</groupId>
@@ -34,7 +34,7 @@
         <maven.jar.plugin.automatic.module.name>de.cuioss.test.keycloakit</maven.jar.plugin.automatic.module.name>
         <version.testcontainers-keycloak>3.8.0</version.testcontainers-keycloak>
         <version.testcontainer>1.21.3</version.testcontainer>
-        <version.cui.parent>0.9.9.6</version.cui.parent>
+        <version.cui.parent>1.1.0</version.cui.parent>
         <!-- Fixes the problem:
     Error: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.21.0:site (default-site) on project portal.authentication.token: Failed to render site: Error generating maven-javadoc-plugin:3.11.1:javadoc report: Unable to derive module descriptor for /home/runner/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-impl-base/2.0.0-beta-2/shrinkwrap-impl-base-2.0.0-beta-2.jar: Provider class implementingClassName=org.jboss.shrinkwrap.impl.base.importer.zip.ZipImporterImpl not in module -> [Help 1]-->
         <maven.javadoc.plugin.legacyMode>true</maven.javadoc.plugin.legacyMode>

--- a/src/main/java/de/cuioss/test/keycloakit/KeycloakITBase.java
+++ b/src/main/java/de/cuioss/test/keycloakit/KeycloakITBase.java
@@ -1,12 +1,12 @@
-/*
- * Copyright 2023 the original author or authors.
- * <p>
+/**
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,8 +37,7 @@ public class KeycloakITBase {
         public static final String ID_TOKEN = "id_token";
     }
 
-    @Container
-    KeycloakContainer keycloak = new KeycloakContainer().withRealmImportFile(TestRealm.REALM_CONFIGURATION).
+    @Container KeycloakContainer keycloak = new KeycloakContainer().withRealmImportFile(TestRealm.REALM_CONFIGURATION).
             withAdminUsername(TestRealm.Administrator.NAME).withAdminPassword(TestRealm.Administrator.PASSWORD)
             .useTls();
 

--- a/src/main/java/de/cuioss/test/keycloakit/TestRealm.java
+++ b/src/main/java/de/cuioss/test/keycloakit/TestRealm.java
@@ -1,12 +1,12 @@
-/*
- * Copyright 2023 the original author or authors.
- * <p>
+/**
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/de/cuioss/test/keycloakit/KeycloakITBaseTest.java
+++ b/src/test/java/de/cuioss/test/keycloakit/KeycloakITBaseTest.java
@@ -1,12 +1,12 @@
-/*
- * Copyright 2023 the original author or authors.
- * <p>
+/**
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
- I updated cui-parent to version 1.1.0 in pom.xml.
- I updated GitHub workflows (maven.yml and maven-release.yml) to use Java 21 as the baseline, removing Java 17.
- I replaced deprecated maven.compiler.source/target with maven.compiler.release in maven.yml.
- I updated .github/project.yml to current-version 1.1.0 and next-version 1.2.0-SNAPSHOT.
- I updated README.adoc Maven Central badge to the new shields.io format.